### PR TITLE
feat(aliases): safer git force push using force-with-lease

### DIFF
--- a/src/jlegrone.gitconfig
+++ b/src/jlegrone.gitconfig
@@ -57,6 +57,10 @@
   # Usage: git publish
   publish = "!git push -u origin $(git branch-name)"
 
+  # "Safer" force push -- see http://weiqingtoh.github.io/force-with-lease/
+  # Usage: git pushf
+  pushf = push --force-with-lease
+
   # Delete merged branches
   # Usage: git cleanup
   cleanup = "!git branch --merged | grep  -v '\\*\\|master\\|develop' | xargs -n 1 git branch -d"


### PR DESCRIPTION
Using the `force-with-lease` flag rather than `force` prevents the user
from accidentally overwriting new commits present only on the remote.