### PR TITLE
feat(main-branch): add support for Github main branch

### DIFF
--- a/commitizen.config.js
+++ b/commitizen.config.js
@@ -63,7 +63,8 @@ const scopes = [
   'status',
   'branch-name',
   'develop-branch',
-  'upstream-or-origin'
+  'upstream-or-origin',
+  'main-branch'
 ].map(name => ({ name }));
 
 module.exports = {

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -14,8 +14,5 @@ module.exports = {
     // Apply valid scopes and types
     'scope-enum': [scopeValidationLevel, 'always', validScopes],
     'type-enum': [2, 'always', validTypes],
-
-    // Disable language rule
-    lang: [0, 'always', 'eng']
   }
 };

--- a/src/jlegrone.gitconfig
+++ b/src/jlegrone.gitconfig
@@ -22,7 +22,7 @@
 
   # Start a hotfix branch based off of latest master branch
   # Usage: git hotfix <name-of-production-patch>
-  hotfix = "!sh -c \"git checkout master && git pull && git cb hotfix/$1\" -"
+  hotfix = "!sh -c \"git checkout $(git main-branch) && git pull && git cb hotfix/$1\" -"
 
   # Create a "work in progress" commit with your current changes
   # Usage: git wip
@@ -67,7 +67,7 @@
 
   # Delete merged branches
   # Usage: git cleanup
-  cleanup = "!git branch --merged | grep  -v '\\*\\|master\\|develop' | xargs -n 1 git branch -d"
+  cleanup = "!git branch --merged | grep  -v '\\*\\|main\\|master\\|develop' | xargs -n 1 git branch -d"
 
   # Create a new branch
   # Usage: git cb <branch-name>
@@ -85,7 +85,10 @@
   branch-name = "!git rev-parse --abbrev-ref HEAD"
 
   # Get the develop branch (used in other aliases)
-  develop-branch = "!(git show-ref --quiet refs/heads/develop && echo develop) || echo master"
+  develop-branch = "!(git show-ref --quiet refs/heads/develop && echo develop) || echo $(git main-branch)"
 
   # Get remote name (prefer upstream over origin)
   upstream-or-origin = "!(git remote | grep upstream) || echo origin"
+
+  # Get main branch name (prefer main over master)
+  main-branch="!(git show-ref --quiet refs/heads/main && echo main) || echo master"


### PR DESCRIPTION
This implements support for the `main` branch name that is now used by Github in place of `master`
but falls back to `master` if `main` isn't found.

I found that some of the aliases didn't seem to like the fact that I didn't have a `master` branch for repositories that I created via Github first and then cloned, so I tried to follow the same pattern you did with the `upstream`/`origin` logic.

I've been running with it locally for a little bit and it seems to work pretty well.

**Note**: I had to remove the `lang` rule because the commit lint step was failing due to not recognizing that as a valid rule.