### PR TITLE
feat(aliases): add warning and --no-user-check flag for undo

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,11 @@ Create a "work in progress" commit with all (staged and unstaged) changes.
 
 <hr>
 
-#### `git undo`
+#### `git undo [--no-user-check]`
 
 Undo the latest commit. The contents of that commit will remain as staged changes.
+
+> Note: The `--no-user-check` flag is required if the previous author is not the current user.
 
 <hr>
 

--- a/src/jlegrone.gitconfig
+++ b/src/jlegrone.gitconfig
@@ -28,9 +28,9 @@
   # Usage: git wip
   wip = !git add . && git commit -am "WIP" --no-verify
 
-  # Undo your last commit
-  # Usage: git undo
-  undo = reset --soft HEAD~1
+  # Undo the last commit
+  # Usage: git undo | git undo --no-user-check
+  undo = "!sh -c \"([ "$(git same-committer)" == 1 ] && git reset --soft HEAD~1 || ([ -z "$1" ] && echo "Previous commit made by $(git previous-committer). If you would like to revert to that commit run 'git undo --no-user-check'" || ([ "$1" == "--no-user-check" ] && echo "undo" || echo "Unrecognized parameter")))\" -"
 
   # Amend your last commit to include current changes
   # ** Rewrites history **
@@ -89,3 +89,12 @@
 
   # Get remote name (prefer upstream over origin)
   upstream-or-origin = "!(git remote | grep upstream) || echo origin"
+
+  # Get name of previous committer
+  previous-committer = log -1 --pretty=format:'%an'
+
+  # Get name of current committer
+  current-committer = config --get user.name
+
+  # Compare previous-committer to current-committer
+  same-committer = "!sh -c \"[[ '"$(git previous-committer)"' == '"$(git current-committer)"' ]] && echo 1 || echo 0\" -"


### PR DESCRIPTION
This prompts the user to rerun `git undo` with the `--no-user-check` flag when a different user authored
the previous commit.

BREAKING CHANGE:
git undo no longer works as expected when a different user authored the previous commit; git undo
`--no-user-check` is required in that case

ISSUES CLOSED: #23